### PR TITLE
Rebuild against python 3.14

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,15 +12,12 @@ source:
     - patches/0001-avoid-strict-pinning.patch
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - stone=stone.cli:main
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
-  build:
-    - m2-patch  # [win]
-    - patch     # [not win]
   host:
     - pip
     # No need strict pinning
@@ -53,7 +50,9 @@ test:
     - pytest test  # [not win]
   requires:
     - pip
-    - pytest <7
+    - pytest <7 # [py<314]
+    # pytest <7 doesn't support py>=3.14, so we need to allow pytest 7 for py>=3.14
+    - pytest 7 # [py>=314]
     - mock >=2.0.0,<5.0
 
 about:


### PR DESCRIPTION
stone 3.3.9

**Destination channel:** defaults

### Links

- [PKG-13449](https://anaconda.atlassian.net/browse/PKG-13449) 
- [Upstream repository](https://github.com/dropbox/stone)

### Explanation of changes:
- Rebuild against python 3.14


[PKG-13449]: https://anaconda.atlassian.net/browse/PKG-13449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ